### PR TITLE
Temporarily stop installing pysnmp

### DIFF
--- a/scripts/monitoring/proxy_snmp/install_requirements.sh
+++ b/scripts/monitoring/proxy_snmp/install_requirements.sh
@@ -2,4 +2,4 @@
 
 sudo apt update
 sudo apt install gcc -y
-pip install pysnmp==4.3.5
+#pip install pysnmp==4.3.5


### PR DESCRIPTION
It fails due to the deprecation of non-SNI compatible clients [1].
As it parts of RC1 and as this package is optional, we can skip it to
get the VNF testing in success.

[1] https://github.com/pypa/pypi-support/issues/978

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>
(cherry picked from commit 6de8a148b487899b87cadf4c5cc6955d9365976f)